### PR TITLE
Cache parsed jsonpath expressions for a 90000% speedup

### DIFF
--- a/mtd/parsers/dict_parser.py
+++ b/mtd/parsers/dict_parser.py
@@ -16,6 +16,7 @@ class Parser(JsonParser):
     :param ResourceManifest manifest: Manifest for parser
     '''
     def __init__(self, manifest: ResourceManifest, resource: Union[dict, list]):
+        self.path_cache = {}
         self.manifest = manifest
         self.resource = resource
         if "location" in self.manifest:

--- a/mtd/parsers/pkl_parser.py
+++ b/mtd/parsers/pkl_parser.py
@@ -18,6 +18,7 @@ class Parser(JsonParser):
     :param (str or json) resource_path: Dict or path to pkl
     '''
     def __init__(self, manifest: ResourceManifest, resource_path: Union[str, dict, list]):
+        self.path_cache = {}
         self.manifest = manifest
         try:
             if isinstance(resource_path, str):


### PR DESCRIPTION
The same jsonpath expressions were being compiled (slowly) for every. single. entry. in the dictionary.

Instead we can cache them (there aren't very many of them) in the parser object.  It's not quite as fast as CSV but still pretty fast, goes from 20 entries per second to 1800 entries per second on my data.