### PR TITLE
Correct the null row removal and use of return_null

### DIFF
--- a/mtd/dictionary.py
+++ b/mtd/dictionary.py
@@ -43,10 +43,9 @@ class Dictionary():
             do['data'] = do['data'].replace('', nan)
             null_rows = return_null(do['data'])
             if null_rows:
-                logger.warning('Removing entries with no "word" in %s: %s',
-                               d["resource"], null_rows)
+                logger.warning('Removing entries with no "word" in %s', d["resource"])
                 do['data'] = do['data'].dropna(subset=['word'], how='all')
-            # Don't leave NaNs lying around!
+            # Don't leave NaNs lying around, as transduce() will fail, cryptically!
             do['data'] = do['data'].replace(nan, "")
         # transduce
         self.transduce()
@@ -62,8 +61,10 @@ class Dictionary():
                            "or some entryIDs were missing. Using index instead. "
                            "Note, this will not be consistent across builds.")
             self._df['entryID'] = self._df.index.astype(str)
-        # log dupes
+        # log dupes (FIXME: no, this does not actually do that)
         dupes = return_dupes(self._df)
+        # restore null values so validation will work
+        do['data'] = do['data'].replace('', None)
         
     def __len__(self):
         return len(self._df.index)

--- a/mtd/dictionary.py
+++ b/mtd/dictionary.py
@@ -33,6 +33,7 @@ class Dictionary():
     def __init__(self, language_config):
         self.config = language_config['config']
         self.name = slugify(self.config['L1'])
+        logger.info("Parsing data")
         # parse
         self.data_objs = [parse(d['manifest'], d['resource']) for d in language_config['data']]
         # validate
@@ -48,8 +49,10 @@ class Dictionary():
             # Don't leave NaNs lying around, as transduce() will fail, cryptically!
             do['data'] = do['data'].replace(nan, "")
         # transduce
+        logger.info("Applying approximate search transducers")
         self.transduce()
         # sort
+        logger.info("Sorting entries")
         self.sort()
         # join
         self._df = self.joined()
@@ -62,9 +65,9 @@ class Dictionary():
                            "Note, this will not be consistent across builds.")
             self._df['entryID'] = self._df.index.astype(str)
         # log dupes (FIXME: no, this does not actually do that)
+        logger.info("Finding duplicate entries")
         dupes = return_dupes(self._df)
-        # restore null values so validation will work
-        do['data'] = do['data'].replace('', None)
+        logger.info("DONE!")
         
     def __len__(self):
         return len(self._df.index)

--- a/mtd/processors/validator.py
+++ b/mtd/processors/validator.py
@@ -3,7 +3,7 @@ from mtd.tests import logger
 from pandas import concat, DataFrame
 from typing import List, Union
 
-def return_null(df, notnull: List[str]=['word', 'definition']) -> bool:
+def return_null(df, notnull: List[str]=['word', 'definition']) -> List:
     """Returns a list of null items
 
     :param list notnull: list of keys to guarantee non-null values for
@@ -18,8 +18,8 @@ def return_null(df, notnull: List[str]=['word', 'definition']) -> bool:
                 all_null_values.append(df[df[col].isnull()].values)
             return all_null_values
     else:
-        e = DfMissingKeysValidationError(notnull)
-        logger.error(e)
+        raise DfMissingKeysValidationError(notnull)
+
 
 def check_alphabet(alphabet: List[str], df: DataFrame, key: str = 'word') -> List[str]:
     ''' Checks if any characters exist in the DataFrame that aren't in the alphabet.

--- a/mtd/processors/validator.py
+++ b/mtd/processors/validator.py
@@ -47,8 +47,8 @@ def remove_dupes(df) -> DataFrame:
     dupes_removed = df.drop_duplicates(subset=["word", "definition"])
     return dupes_removed
 
-def return_dupes(df, dupe_columns: List[str] = ['word']) -> DataFrame:
-    '''return all word/definition duplicates. TODO: why does ['word', 'definition'] not work for dupe_columns?
+def return_dupes(df, dupe_columns: List[str] = ['word', 'definition']) -> DataFrame:
+    '''return all word/definition duplicates.
     '''
     dupes = df.loc[df.duplicated(subset=dupe_columns, keep=False)]
     dupe_msgs = []

--- a/mtd/processors/validator.py
+++ b/mtd/processors/validator.py
@@ -3,10 +3,15 @@ from mtd.tests import logger
 from pandas import concat, DataFrame
 from typing import List, Union
 
-def return_null(df, notnull: List[str]=['word', 'definition']) -> List:
-    """Returns a list of null items
+def return_null(df, notnull: List[str]=['word', 'definition']) -> List[List]:
+    """Returns a list of lists of null items for each column in `notnull`.
+
+    If no null items at all were found, returns the empty list.
+    Raises DfMissingKeysValidationError if any of the columns in
+    `notnull` are missing.
 
     :param list notnull: list of keys to guarantee non-null values for
+
     """
     if all([nn in df for nn in notnull]):
         is_not_null = all([df[nn].notnull().all() for nn in notnull])

--- a/mtd/templates/validator.html
+++ b/mtd/templates/validator.html
@@ -218,8 +218,8 @@
     },
     "data": [
         {
-            "manifest": "/Users/pinea/mothertongues/mtd/languages/mohegan/manifest.json",
-            "resource": "/Users/pinea/mothertongues/mtd/languages/mohegan/data.json"
+            "manifest": "mtd/languages/mohegan/manifest.json",
+            "resource": "mtd/languages/mohegan/data.json"
         }
     ],
     "adhoc_vars": [

--- a/mtd/tests/test_validator.py
+++ b/mtd/tests/test_validator.py
@@ -1,25 +1,36 @@
 from unittest import TestCase
 from mtd.tests import SAMPLE_DATA_OBJ, SAMPLE_DATA_DF
 from mtd.processors.validator import return_null, return_dupes, remove_dupes
+from mtd.exceptions import DfMissingKeysValidationError
 from pandas import DataFrame
 from copy import deepcopy
 
+
 class ValidatorTest(TestCase):
-    def setUp(self):
-        self.duped_data = DataFrame([SAMPLE_DATA_OBJ[0], SAMPLE_DATA_OBJ[0]])
-        missing_key = deepcopy(SAMPLE_DATA_OBJ)
-        missing_key[0].pop('word')
-        self.missing_key_data = DataFrame(missing_key)
-        missing_val = deepcopy(SAMPLE_DATA_OBJ)
-        missing_val[0]['word'] = ''
-        self.missing_value_data = DataFrame(missing_val)
-    
     def test_missing_key(self):
-        self.assertFalse(return_null(self.missing_key_data))
+        missing_key = deepcopy(SAMPLE_DATA_OBJ)
+        missing_key[0].pop("word")
+        missing_key_data = DataFrame(missing_key)
+        with self.assertRaises(DfMissingKeysValidationError):
+            _ = return_null(missing_key_data)
 
     def test_missing_value(self):
-        self.assertFalse(return_null(self.missing_value_data))
+        missing_val = deepcopy(SAMPLE_DATA_OBJ)
+        # Empty string does not count as null!
+        missing_val[0]["word"] = ""
+        missing_value_data = DataFrame(missing_val)
+        self.assertEqual([], return_null(missing_value_data))
+        # None does count as null (Pandas will probably make it NaN)
+        missing_val[0]["word"] = None
+        missing_value_data = DataFrame(missing_val)
+        missing_values_by_column = return_null(
+            missing_value_data, ["word", "definition"]
+        )
+        # Missing word, but not definition
+        self.assertNotEqual(0, len(missing_values_by_column[0]))
+        self.assertEqual(0, len(missing_values_by_column[1]))
 
     def test_dupes(self):
-        self.assertTrue(SAMPLE_DATA_DF.equals(remove_dupes(self.duped_data)))
-        self.assertTrue(len(return_dupes(self.duped_data)) == 2)
+        duped_data = DataFrame([SAMPLE_DATA_OBJ[0], SAMPLE_DATA_OBJ[0]])
+        self.assertTrue(SAMPLE_DATA_DF.equals(remove_dupes(duped_data)))
+        self.assertTrue(len(return_dupes(duped_data)) == 2)


### PR DESCRIPTION
The type annotation for `return_null` was quite incorrect, and its output wasn't really documented or well tested.  This fixes that.

Also the validation of "entryID" just didn't work, so this fixes that too.

Also, if columns other than "word" contained empty values we would end up with NaN in the output.  It's not clear to me if these should be removed or if this should be an error, but it previously caused a confusing exception.