### PR TITLE
Make listof implementation for json somewhat more sensible and documented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ mtd/static/assets/js/config-h-nq-min-m.js
 mtd/static/assets/js/config-test.js
 mtd/static/assets/js/dict_cached-h-nq-min-m.js
 mtd/static/assets/js/dict_cached-test.js
+*~

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "useTabs": false,
+    "printWidth": 80,
+    "tabWidth": 4,
+    "trailingComma": "none"
+}

--- a/mtd/languages/config_schema.json
+++ b/mtd/languages/config_schema.json
@@ -1,22 +1,30 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://mothertongues.org/config_schema.json",
+    "description": "Configuration for MTD dictionary",
     "type": "object",
     "properties": {
         "config": {
             "type": "object",
             "properties": {
                 "L1": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of language of headwords"
                 },
                 "L2": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of language of definitions"
                 },
                 "L1_compare_transducer_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of transducer to expand L1 queries (FIXME: unused)"
                 },
                 "optional_field_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of field with optional value (FIXME: unused)"
                 },
                 "alphabet": {
+                    "description": "List of characters in L1 alphabet",
                     "oneOf": [
                         {
                             "type": "string"
@@ -31,6 +39,7 @@
                 },
                 "credits": {
                     "type": "array",
+                    "description": "List of authors and contributors",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -56,13 +65,11 @@
                     }
                 }
             },
-            "required": [
-                "L1",
-                "L2"
-            ]
+            "required": ["L1", "L2"]
         },
         "data": {
             "type": "array",
+            "description": "Paths to input files (manifest and input data)",
             "items": {
                 "type": "object",
                 "properties": {
@@ -78,18 +85,12 @@
                     },
                     "resource": {}
                 },
-                "required": [
-                    "manifest",
-                    "resource"
-                ]
+                "required": ["manifest", "resource"]
             }
         },
         "github_credentials_path": {
             "type": "string"
         }
     },
-    "required": [
-        "config",
-        "data"
-    ]
+    "required": ["config", "data"]
 }

--- a/mtd/languages/manifest_schema.json
+++ b/mtd/languages/manifest_schema.json
@@ -1,22 +1,31 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "definitions": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://mothertongues.org/manifest_schema.json",
+    "title": "Mother Tongues Dictionary Manifest",
+    "description": "Manifest for constructing MTD dictionary",
+    "$defs": {
         "audio": {
             "type": "object",
+            "description": "Clip of recorded audio with optional word alignments",
             "properties": {
                 "speaker": {
                     "type": "string"
                 },
                 "filename": {
                     "type": "string"
+                },
+                "starts": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
             },
-            "required": [
-                "filename"
-            ]
+            "required": ["filename"]
         },
         "listof": {
             "type": "object",
+            "description": "Extract a list of items from the input data",
             "properties": {
                 "listof": {
                     "type": "string"
@@ -31,92 +40,106 @@
                         }
                     ]
                 }
-            }
+            },
+            "required": ["listof"]
         }
     },
     "type": "object",
     "properties": {
         "file_type": {
             "type": "string",
+            "description": "Type of input file",
             "enum": ["csv", "json", "psv", "pkl", "tsv", "xlsx", "xml"]
         },
         "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of dictionary"
         },
         "display": {
-            "type": "string"
+            "type": "string",
+            "description": "Primary field for display (not used)"
         },
         "location": {
             "type": "string"
         },
         "skipheader": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Skip header row in tabular (csv, psv, tsv, xlsx) input"
         },
         "compare": {
-            "type": "string"
+            "type": "string",
+            "description": "Field used for comparing entries"
         },
         "sorting": {
-            "type": "string"
+            "type": "string",
+            "description": "Field used for sorting entries"
         },
         "transducers": {
             "type": "array",
+            "description": "Transducers used to generate targets (e.g. for search)",
             "items": {
                 "type": "object",
                 "properties": {
                     "source": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Source field"
                     },
                     "target": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Target field"
                     },
                     "functions": {
                         "type": "array",
                         "items": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "G2P transducer as YAML file or text of Python lambda"
                         }
                     }
                 },
-                "required": [
-                    "source",
-                    "target",
-                    "functions"
-                ]
+                "required": ["source", "target", "functions"]
             }
         },
         "targets": {
             "type": "object",
+            "definition": "Target fields in output and where to find them",
             "properties": {
                 "word": {
-                    "type": "string"
+                    "type": "string",
+                    "definition": "Word in L1"
                 },
                 "definition": {
-                    "type": "string"
+                    "type": "string",
+                    "definition": "Definition in L2"
                 },
                 "entryID": {
-                    "type": "string"
+                    "type": "string",
+                    "definition": "Unique entry ID (will be generated if missing)"
                 },
                 "optional": {
                     "type": "array",
+                    "definition": "Optional information for display, e.g. part of speech",
                     "items": {
                         "type": "object"
                     }
                 },
                 "theme": {
-                    "type": "string"
+                  "type": "string",
+                  "definition": "Primary semantic category"
                 },
                 "secondary_theme": {
-                    "type": "string"
+                  "type": "string",
+                  "definition": "Secondary semantic category"
                 },
                 "audio": {
                     "oneOf": [
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/audio"
+                                "$ref": "#/$defs/audio"
                             }
                         },
                         {
-                            "$ref": "#/definitions/listof"
+                            "$ref": "#/$defs/listof"
                         }
                     ]
                 },
@@ -125,11 +148,11 @@
                         {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/audio"
+                                "$ref": "#/$defs/audio"
                             }
                         },
                         {
-                            "$ref": "#/definitions/listof"
+                            "$ref": "#/$defs/listof"
                         }
                     ]
                 },
@@ -142,7 +165,7 @@
                             }
                         },
                         {
-                            "$ref": "#/definitions/listof"
+                            "$ref": "#/$defs/listof"
                         }
                     ]
                 },
@@ -155,7 +178,7 @@
                             }
                         },
                         {
-                            "$ref": "#/definitions/listof"
+                            "$ref": "#/$defs/listof"
                         }
                     ]
                 },
@@ -166,12 +189,12 @@
                             "items": {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/definitions/audio"
+                                    "$ref": "#/$defs/audio"
                                 }
                             }
                         },
                         {
-                            "$ref": "#/definitions/listof"
+                            "$ref": "#/$defs/listof"
                         }
                     ]
                 },
@@ -182,28 +205,22 @@
                             "items": {
                                 "type": "array",
                                 "items": {
-                                    "$ref": "#/definitions/audio"
+                                    "$ref": "#/$defs/audio"
                                 }
                             }
                         },
                         {
-                            "$ref": "#/definitions/listof"
+                            "$ref": "#/$defs/listof"
                         }
                     ]
                 },
                 "img": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Image for this entry"
                 }
             },
-            "required": [
-                "word",
-                "definition"
-            ]
+            "required": ["word", "definition"]
         }
     },
-    "required": [
-        "name",
-        "sorting",
-        "targets"
-    ]
+    "required": ["name", "sorting", "targets"]
 }

--- a/mtd/languages/manifest_schema.json
+++ b/mtd/languages/manifest_schema.json
@@ -107,6 +107,10 @@
                     "type": "string",
                     "definition": "Word in L1"
                 },
+                "sense": {
+                    "type": "string",
+                    "definition": "Particular sense of word in L1"
+                },
                 "definition": {
                     "type": "string",
                     "definition": "Definition in L2"

--- a/mtd/parsers/json_parser.py
+++ b/mtd/parsers/json_parser.py
@@ -68,8 +68,10 @@ class Parser(BaseParser):
         if "value" in listof_dict:
             if isinstance(listof_dict['value'], dict) and "listof" in listof_dict['value']:
                 # Recurse one level down (apparently no more than this)
-                listof_dict['listof'] = listof_dict['value']['listof']
-                listof_dict['value'] = listof_dict['value']['value']
+                next_listof_dict = {
+                    "listof": listof_dict['value']['listof'],
+                    "value": listof_dict['value']['value'],
+                }
                 # `listof` will usually have only one element, which
                 # is the actual list we were looking for
                 for el in listof:
@@ -77,7 +79,7 @@ class Parser(BaseParser):
                     if isinstance(items, dict):
                         items = [items]
                     for item in items:
-                        new_el = self.fill_listof_entry_template(listof_dict, item, convert_function)
+                        new_el = self.fill_listof_entry_template(next_listof_dict, item, convert_function)
                         new_els.append(new_el)
             elif isinstance(listof_dict['value'], dict):
                 # Create outputs with dictionaries of queries from "value" on results

--- a/mtd/parsers/json_parser.py
+++ b/mtd/parsers/json_parser.py
@@ -67,7 +67,6 @@ class Parser(BaseParser):
         new_els = []
         if "value" in listof_dict:
             if isinstance(listof_dict['value'], dict) and "listof" in listof_dict['value']:
-                # Recurse one level down (apparently no more than this)
                 next_listof_dict = {
                     "listof": listof_dict['value']['listof'],
                     "value": listof_dict['value']['value'],

--- a/mtd/parsers/json_parser.py
+++ b/mtd/parsers/json_parser.py
@@ -68,9 +68,14 @@ class Parser(BaseParser):
                     items = el.value
                     if isinstance(items, dict):
                         items = [items]
-                    for item in items:
-                        new_el = self.fill_listof_entry_template(listof_dict, item, convert_function)
+                    # Special case for more reasonable behaviour of not flattening the list
+                    if listof_dict["listof"] == "$":
+                        new_el = self.fill_listof_entry_template(listof_dict, items, convert_function)
                         new_els.append(new_el)
+                    else:
+                        for item in items:
+                            new_el = self.fill_listof_entry_template(listof_dict, item, convert_function)
+                            new_els.append(new_el)
             elif isinstance(listof_dict['value'], dict):
                 # Create outputs with dictionaries of queries from "value" on results
                 for el in listof:

--- a/mtd/parsers/json_parser.py
+++ b/mtd/parsers/json_parser.py
@@ -76,7 +76,8 @@ class Parser(BaseParser):
                 new_els.append(new_el)
         else:
             for el in listof:
-                new_els.append(el.value)
+                for item in el.value:
+                    new_els.append(item)
 
         return new_els
 

--- a/mtd/parsers/json_parser.py
+++ b/mtd/parsers/json_parser.py
@@ -53,29 +53,32 @@ class Parser(BaseParser):
         ]
 
     def fill_listof_entry_template(self, listof_dict: dict, entry, convert_function) -> list:
-        # Run the query
+        """Handle a "listof" template in the manifest.
+
+        The logic here is not very obvious due to weirdity of
+        jsonpath.  See `fill_entry_template` for a description of the
+        semantics.
+
+        """
+        # Run the query (convert function is always getValueFromJsonPath)
         listof = convert_function(entry, listof_dict['listof'])
         if not listof:
             return listof
         new_els = []
         if "value" in listof_dict:
-            # Legacy (somewhat bogus) behaviour, which assumes an extra list somewhere
             if isinstance(listof_dict['value'], dict) and "listof" in listof_dict['value']:
                 # Recurse one level down (apparently no more than this)
                 listof_dict['listof'] = listof_dict['value']['listof']
                 listof_dict['value'] = listof_dict['value']['value']
+                # `listof` will usually have only one element, which
+                # is the actual list we were looking for
                 for el in listof:
                     items = el.value
                     if isinstance(items, dict):
                         items = [items]
-                    # Special case for more reasonable behaviour of not flattening the list
-                    if listof_dict["listof"] == "$":
-                        new_el = self.fill_listof_entry_template(listof_dict, items, convert_function)
+                    for item in items:
+                        new_el = self.fill_listof_entry_template(listof_dict, item, convert_function)
                         new_els.append(new_el)
-                    else:
-                        for item in items:
-                            new_el = self.fill_listof_entry_template(listof_dict, item, convert_function)
-                            new_els.append(new_el)
             elif isinstance(listof_dict['value'], dict):
                 # Create outputs with dictionaries of queries from "value" on results
                 for el in listof:
@@ -89,27 +92,131 @@ class Parser(BaseParser):
                             new_el[k] = self.validate_type(k, [match.value for match in new_json_expr.find(item)])
                         new_els.append(new_el)
             else:
-                # Do ... something, totally ignoring the "value" key
                 for el in listof:
                     items = el.value
                     if isinstance(items, dict):
                         items = [items]
                     for item in items:
-                        new_els.append(item)
+                        new_json_expr = self.get_matcher(listof_dict["value"].strip())
+                        for match in new_json_expr.find(item):
+                            new_els.append(match.value)
         else:
-            # New mode, just give me the list of items THAT I ASKED FOR
+            # No "value" is a synonym for "$", i.e. identity function
             for el in listof:
-                new_els.append(el.value)
+                # We use "extend" here because of jsonpath's
+                # frustrating feature of always wrapping things in
+                # lists...
+                new_els.extend(el.value)
 
         return new_els
 
     def fill_entry_template(self, entry_template: dict, entry, convert_function) -> dict:
-        '''This recursive function "fills in" the data according to the resource manifest. This is a slight modification from the one used by all parsers.
+        '''This recursive function "fills in" the data according to the
+        resource manifest. This is a slight modification from the one used by
+        all parsers.
+
+        The logic here is not always obvious due to weirdity of
+        jsonpath among other things.
+
+        In the case of a scalar value, no problem, e.g. if your JSON has:
+
+            {
+                "audio": {
+                     "speaker": "Eric Idle",
+                     "filename": "spam.mp3"
+                },
+                "examples": [ "spam", "spam", "eggs", "spam" ],
+                "example_audio": [
+                     { "speaker": "Viking 1" },
+                     { "speaker": "Viking 2" },
+                     { "speaker": "Viking 3" },
+                     { "speaker": "Viking 4" }
+                ]
+            }
+
+        Then a value in the manifest like "audio.speaker" will yield
+        the string "Eric Idle".
+
+        If you want to create a list of a fixed length, or a
+        dictionary, in the output, you can do that too, e.g.
+
+            [ "examples[0]", "examples[2]" ]
+
+        will yield `[ "spam", "eggs" ]`,
+        and
+        
+            { "spam": "examples[0]", "eggs", "examples[2]" }
+
+        will yield `{ "spam": "spam", "eggs": "eggs" }`.
+
+        But if you want to construct a list of variable length, you
+        have to use "listof", *even if* you are simply passing through
+        an existing list from the input.  This is because the JSON
+        schema validation does not know that "examples" in the input
+        above has a list as its value.  So you have to use "listof",
+        which means that your value is a dictionary with two keys,
+        "listof" and "value".  This runs the value of "listof" as a
+        query which is expected to return a ... list of things.  The
+        output is then constructed by running the query in "value" on
+        *each item in* that list.  So, for instance:
+
+            "vikings": { "listof": "example_audio", "value": "speaker" }
+
+        should give you a list of Vikings.  If you don't want to
+        actually run any query on the items (e.g., they are just
+        strings), you can use "$" as the "value", or actually just
+        omit "value" entirely, which does the same thing, e.g.:
+        
+            "examples": { "listof": "examples", "value": "$" }
+            "examples": { "listof": "examples" }
+
+        You can nest listofs, but be aware that the embedded "listof"
+        query will be applied *to each entry in the list returned by
+        the parent query*, and these results will be collected in a
+        list, so in the case of lists of lists, you need to take care
+        not to flatten your data - this can be achieved by using "$"
+        as the second-level "listof" query, e.g. if your JSON has:
+
+            "example_audio2": [
+                [ { "speaker": "Viking 1", "filename": "spam1.mp3" },
+                  { "speaker": "Viking 2", "filename": "spam2.mp3" },
+                 ],
+                [
+                    { "speaker": "Viking 3", "filename": "spam3.mp3" },
+                    { "speaker": "Viking 4", "filename": "spam4.mp3" },
+                ]
+            ]
+
+        Then you could use this to extract the "speaker" value:
+
+            "vikings2": {
+                "listof": "example_audio2",
+                "value": {
+                    "listof": "$",
+                    "value": {
+                        "speaker": "speaker",
+                        "filename": "filename"
+                    }
+                }
+            }
+
+        Finally, because jsonpath is weird, it is not recommended to
+        use the `[*]` syntax to get all items of a list, because this
+        will cause it to get flattened as well.
 
         Args:
-            :param dict entry_template: The template for an entry. Keys are preserved, values are usually paths in the resource to data (JSONPath, XPath or Cell coordinates etc)
-            :param any entry: The actual word/entry to extract some data from. This could be a row, or json dict or any piece of nested data from the data resource.
-            :param function convert_function: A function that takes an entry and a path and returns the "filled in" object
+
+            :param dict entry_template: The template for an
+            entry. Keys are preserved, values are usually paths in the
+            resource to data (JSONPath, XPath or Cell coordinates etc)
+
+            :param any entry: The actual word/entry to extract some
+            data from. This could be a row, or json dict or any piece
+            of nested data from the data resource.
+
+            :param function convert_function: A function that takes an
+            entry and a path and returns the "filled in" object
+
         '''
         new_lemma = {}
         for k, v in entry_template.items():

--- a/mtd/parsers/json_parser.py
+++ b/mtd/parsers/json_parser.py
@@ -65,16 +65,19 @@ class Parser(BaseParser):
                 listof_dict['listof'] = listof_dict['value']['listof']
                 listof_dict['value'] = listof_dict['value']['value']
                 for el in listof:
-                    for item in el.value:
-                        el = self.fill_listof_entry_template(listof_dict, [item], convert_function)
-                        new_els.append(el)
-            elif "value" in listof_dict and isinstance(listof_dict['value'], dict):
+                    items = el.value
+                    if isinstance(items, dict):
+                        items = [items]
+                    for item in items:
+                        new_el = self.fill_listof_entry_template(listof_dict, item, convert_function)
+                        new_els.append(new_el)
+            elif isinstance(listof_dict['value'], dict):
                 # Create outputs with dictionaries of queries from "value" on results
                 for el in listof:
                     items = el.value
                     if isinstance(items, dict):
                         items = [items]
-                    for item in el.value:
+                    for item in items:
                         new_el = {}
                         for k, v in listof_dict['value'].items():
                             new_json_expr = self.get_matcher(v.strip())
@@ -83,7 +86,10 @@ class Parser(BaseParser):
             else:
                 # Do ... something, totally ignoring the "value" key
                 for el in listof:
-                    for item in el.value:
+                    items = el.value
+                    if isinstance(items, dict):
+                        items = [items]
+                    for item in items:
                         new_els.append(item)
         else:
             # New mode, just give me the list of items THAT I ASKED FOR

--- a/mtd/parsers/utils.py
+++ b/mtd/parsers/utils.py
@@ -164,7 +164,7 @@ class BaseParser():
     def validate_type(self, k, v):
         '''Some parsers like lxml and jsonpath_ng return lists when the data manifest does not specify a list, this corrects that.
         '''
-        if type(v) == list and len(v) > 0 and type(v[0]) == jsonpath.DatumInContext:
+        if type(v) == list and len(v) == 1 and type(v[0]) == jsonpath.DatumInContext:
             v = v[0].value
         if isinstance(v, list) and len(v) == 1 and self.return_manifest_key_type(k, self.manifest.manifest) != list:
             return v[0]

--- a/mtd/tests/__init__.py
+++ b/mtd/tests/__init__.py
@@ -2,85 +2,168 @@ from . import log
 import logging, coloredlogs
 from pandas import DataFrame
 
+
 class ListHandler(logging.Handler):
     def __init__(self, log_list):
         logging.Handler.__init__(self)
-        logging.basicConfig(format='%(levelname)s - %(message)s')
+        logging.basicConfig(format="%(levelname)s - %(message)s")
         self.log_list = log_list
-        self.level_dict = {0: "Not Set", 10: "Debug", 20: "Info", 30: "Warning", 40: "Error", 50: "Critical"}
+        self.level_dict = {
+            0: "Not Set",
+            10: "Debug",
+            20: "Info",
+            30: "Warning",
+            40: "Error",
+            50: "Critical",
+        }
 
     def emit(self, record):
-        self.log_list.append({'level': self.level_dict[record.levelno], 'msg': record.msg, 'levelno': record.levelno})
+        self.log_list.append(
+            {
+                "level": self.level_dict[record.levelno],
+                "msg": record.msg,
+                "levelno": record.levelno,
+            }
+        )
 
-logger = log.setup_logger('root')
+
+logger = log.setup_logger("root")
 
 SAMPLE_DATA_OBJ = [
     {
-    'audio': [{'speaker': 'AP', 'filename': 'ap_red.mp3'}, {'speaker': 'AR', 'filename': 'ar_red.mp3'}], 
-    'definition': 'red', 
-    'definition_audio': [{'speaker': 'AP', 'filename': 'ap_red_def.mp3'}, {'speaker': 'AR', 'filename': 'ar_red_def.mp3'}], 
-    'entryID': '1', 
-    'example_sentence': ['Har du røde øjne?', 'Døde røde rødøjede rådne røgede ørreder.'], 
-    'example_sentence_audio': [[{'speaker': 'AP', 'filename': 'ap_sent1.mp3'}, {'speaker': 'AR', 'filename': 'ar_sent1.mp3'}], [{'speaker': 'AP', 'filename': 'ap_sent2.mp3'}, {'speaker': 'AR', 'filename': 'ar_sent2.mp3'}]],
-    'example_sentence_definition': ['Do you have red eyes?', 'Dead, red, red-eyed, rotten, smoked trout.'], 
-    'example_sentence_definition_audio': [[{'speaker': 'AP', 'filename': 'ap_def_sent1.mp3'}, {'speaker': 'AR', 'filename': 'ar_def_sent1.mp3'}], [{'speaker': 'AP', 'filename': 'ap_def_sent2.mp3'}, {'speaker': 'AR', 'filename': 'ar_def_sent2.mp3'}]], 
-    'img': 'hund.png', 
-    'optional': [{'Part of Speech': 'adjective'}, {'Source': 'test_data'}], 
-    'secondary_theme': 'basic', 
-    'theme': 'colours', 
-    'word': 'rød'}
-    ]
+        "audio": [
+            {"speaker": "AP", "filename": "ap_red.mp3"},
+            {"speaker": "AR", "filename": "ar_red.mp3"},
+        ],
+        "definition": "red",
+        "definition_audio": [
+            {"speaker": "AP", "filename": "ap_red_def.mp3"},
+            {"speaker": "AR", "filename": "ar_red_def.mp3"},
+        ],
+        "entryID": "1",
+        "example_sentence": [
+            "Har du røde øjne?",
+            "Døde røde rødøjede rådne røgede ørreder.",
+        ],
+        "example_sentence_audio": [
+            [
+                {"speaker": "AP", "filename": "ap_sent1.mp3"},
+                {"speaker": "AR", "filename": "ar_sent1.mp3"},
+            ],
+            [
+                {"speaker": "AP", "filename": "ap_sent2.mp3"},
+                {"speaker": "AR", "filename": "ar_sent2.mp3"},
+            ],
+        ],
+        "example_sentence_definition": [
+            "Do you have red eyes?",
+            "Dead, red, red-eyed, rotten, smoked trout.",
+        ],
+        "example_sentence_definition_audio": [
+            [
+                {"speaker": "AP", "filename": "ap_def_sent1.mp3"},
+                {"speaker": "AR", "filename": "ar_def_sent1.mp3"},
+            ],
+            [
+                {"speaker": "AP", "filename": "ap_def_sent2.mp3"},
+                {"speaker": "AR", "filename": "ar_def_sent2.mp3"},
+            ],
+        ],
+        "img": "hund.png",
+        "optional": [{"Part of Speech": "adjective"}, {"Source": "test_data"}],
+        "secondary_theme": "basic",
+        "theme": "colours",
+        "word": "rød",
+    }
+]
 
 SAMPLE_DATA_OBJ_REDUCED = [
     {
-    'audio': [{'speaker': 'AP', 'filename': 'ap_red.mp3'}], 
-    'definition': 'red', 
-    'definition_audio': [{'speaker': 'AP', 'filename': 'ap_red_def.mp3'}], 
-    'entryID': '1', 
-    'example_sentence': ['Har du røde øjne?'], 
-    'example_sentence_audio': [[{'speaker': 'AP', 'filename': 'ap_sent1.mp3'}]],
-    'example_sentence_definition': ['Do you have red eyes?'], 
-    'example_sentence_definition_audio': [[{'speaker': 'AP', 'filename': 'ap_def_sent1.mp3'}]], 
-    'img': 'hund.png', 
-    'optional': [{'Part of Speech': 'adjective'}, {'Source': 'test_data'}], 
-    'secondary_theme': 'basic', 
-    'theme': 'colours', 
-    'word': 'rød'}
-    ]
+        "audio": [{"speaker": "AP", "filename": "ap_red.mp3"}],
+        "definition": "red",
+        "definition_audio": [{"speaker": "AP", "filename": "ap_red_def.mp3"}],
+        "entryID": "1",
+        "example_sentence": ["Har du røde øjne?"],
+        "example_sentence_audio": [[{"speaker": "AP", "filename": "ap_sent1.mp3"}]],
+        "example_sentence_definition": ["Do you have red eyes?"],
+        "example_sentence_definition_audio": [
+            [{"speaker": "AP", "filename": "ap_def_sent1.mp3"}]
+        ],
+        "img": "hund.png",
+        "optional": [{"Part of Speech": "adjective"}, {"Source": "test_data"}],
+        "secondary_theme": "basic",
+        "theme": "colours",
+        "word": "rød",
+    }
+]
 
 SAMPLE_DATA_OBJ_REDUCED_EMPTY = [
     {
-    'audio': [{'speaker': 'AP', 'filename': 'ap_red.mp3'}], 
-    'definition': 'red', 
-    'definition_audio': [{'speaker': 'AP', 'filename': 'ap_red_def.mp3'}], 
-    'entryID': '1', 
-    'example_sentence': ['Har du røde øjne?'], 
-    'example_sentence_audio': [[{'speaker': 'AP', 'filename': 'ap_sent1.mp3'}]],
-    'example_sentence_definition': ['Do you have red eyes?'], 
-    'example_sentence_definition_audio': [[{'speaker': 'AP', 'filename': 'ap_def_sent1.mp3'}]], 
-    'img': 'hund.png', 
-    'optional': [{'Part of Speech': 'adjective'}, {'Source': 'test_data'}], 
-    'secondary_theme': 'basic', 
-    'theme': 'colours', 
-    'word': 'rød'}
-    ]
+        "audio": [{"speaker": "AP", "filename": "ap_red.mp3"}],
+        "definition": "red",
+        "definition_audio": [{"speaker": "AP", "filename": "ap_red_def.mp3"}],
+        "entryID": "1",
+        "example_sentence": ["Har du røde øjne?"],
+        "example_sentence_audio": [[{"speaker": "AP", "filename": "ap_sent1.mp3"}]],
+        "example_sentence_definition": ["Do you have red eyes?"],
+        "example_sentence_definition_audio": [
+            [{"speaker": "AP", "filename": "ap_def_sent1.mp3"}]
+        ],
+        "img": "hund.png",
+        "optional": [{"Part of Speech": "adjective"}, {"Source": "test_data"}],
+        "secondary_theme": "basic",
+        "theme": "colours",
+        "word": "rød",
+    }
+]
 
 SAMPLE_DATA_OBJ_BLANK = [
     {
-    'audio': [{'speaker': 'AP', 'filename': 'ap_red.mp3'}, {'speaker': 'AR', 'filename': 'ar_red.mp3'}], 
-    'definition': 'red', 
-    'definition_audio': [{'speaker': 'AP', 'filename': 'ap_red_def.mp3'}, {'speaker': '', 'filename': ''}], 
-    'entryID': '1', 
-    'example_sentence': ['Har du røde øjne?', 'Døde røde rødøjede rådne røgede ørreder.'], 
-    'example_sentence_audio': [[{'speaker': 'AP', 'filename': 'ap_sent1.mp3'}, {'speaker': 'AR', 'filename': 'ar_sent1.mp3'}], [{'speaker': 'AP', 'filename': 'ap_sent2.mp3'}, {'speaker': 'AR', 'filename': 'ar_sent2.mp3'}]],
-    'example_sentence_definition': ['Do you have red eyes?', 'Dead, red, red-eyed, rotten, smoked trout.'], 
-    'example_sentence_definition_audio': [[{'speaker': 'AP', 'filename': 'ap_def_sent1.mp3'}, {'speaker': 'AR', 'filename': 'ar_def_sent1.mp3'}], [{'speaker': 'AP', 'filename': 'ap_def_sent2.mp3'}, {'speaker': 'AR', 'filename': 'ar_def_sent2.mp3'}]], 
-    'img': 'hund.png', 
-    'optional': [{'Part of Speech': 'adjective'}, {'Source': 'test_data'}], 
-    'secondary_theme': 'basic', 
-    'theme': 'colours', 
-    'word': 'rød'}
-    ]
+        "audio": [
+            {"speaker": "AP", "filename": "ap_red.mp3"},
+            {"speaker": "AR", "filename": "ar_red.mp3"},
+        ],
+        "definition": "red",
+        "definition_audio": [
+            {"speaker": "AP", "filename": "ap_red_def.mp3"},
+            {"speaker": "", "filename": ""},
+        ],
+        "entryID": "1",
+        "example_sentence": [
+            "Har du røde øjne?",
+            "Døde røde rødøjede rådne røgede ørreder.",
+        ],
+        "example_sentence_audio": [
+            [
+                {"speaker": "AP", "filename": "ap_sent1.mp3"},
+                {"speaker": "AR", "filename": "ar_sent1.mp3"},
+            ],
+            [
+                {"speaker": "AP", "filename": "ap_sent2.mp3"},
+                {"speaker": "AR", "filename": "ar_sent2.mp3"},
+            ],
+        ],
+        "example_sentence_definition": [
+            "Do you have red eyes?",
+            "Dead, red, red-eyed, rotten, smoked trout.",
+        ],
+        "example_sentence_definition_audio": [
+            [
+                {"speaker": "AP", "filename": "ap_def_sent1.mp3"},
+                {"speaker": "AR", "filename": "ar_def_sent1.mp3"},
+            ],
+            [
+                {"speaker": "AP", "filename": "ap_def_sent2.mp3"},
+                {"speaker": "AR", "filename": "ar_def_sent2.mp3"},
+            ],
+        ],
+        "img": "hund.png",
+        "optional": [{"Part of Speech": "adjective"}, {"Source": "test_data"}],
+        "secondary_theme": "basic",
+        "theme": "colours",
+        "word": "rød",
+    }
+]
 
 
 SAMPLE_DATA_DF = DataFrame(SAMPLE_DATA_OBJ)

--- a/mtd/tests/test_data/json/dict_manifest.json
+++ b/mtd/tests/test_data/json/dict_manifest.json
@@ -19,12 +19,12 @@
         "theme": "theme",
         "secondary_theme": "secondary_theme",
         "example_sentence": {
-            "listof": "example_sentence",
-            "value": "[*]"
+          "listof": "example_sentence",
+          "value": "this is simply IGNORED!!!"
         },
         "example_sentence_definition": {
             "listof": "example_sentence_definition",
-            "value": "[*]"
+            "value": "it does NOTHING!"
         },
         "example_sentence_audio": {
             "listof": "example_sentence_audio",

--- a/mtd/tests/test_data/json/dict_manifest.json
+++ b/mtd/tests/test_data/json/dict_manifest.json
@@ -19,17 +19,16 @@
         "theme": "theme",
         "secondary_theme": "secondary_theme",
         "example_sentence": {
-          "listof": "example_sentence",
-          "value": "this is simply IGNORED!!!"
+            "listof": "example_sentence",
+            "value": "$"
         },
         "example_sentence_definition": {
-            "listof": "example_sentence_definition",
-            "value": "it does NOTHING!"
+            "listof": "example_sentence_definition"
         },
         "example_sentence_audio": {
             "listof": "example_sentence_audio",
             "value": {
-                "listof": "[*]",
+                "listof": "$",
                 "value": {
                     "speaker": "speaker",
                     "filename": "filename"
@@ -39,7 +38,7 @@
         "example_sentence_definition_audio": {
             "listof": "example_sentence_definition_audio",
             "value": {
-                "listof": "[*]",
+                "listof": "$",
                 "value": {
                     "speaker": "speaker",
                     "filename": "filename"

--- a/mtd/tests/test_data/json/manifest.json
+++ b/mtd/tests/test_data/json/manifest.json
@@ -30,7 +30,7 @@
         "example_sentence_audio": {
             "listof": "example_sentence_audio",
             "value": {
-                "listof": "[*]",
+                "listof": "$",
                 "value": {
                     "speaker": "speaker",
                     "filename": "filename"
@@ -40,7 +40,7 @@
         "example_sentence_definition_audio": {
             "listof": "example_sentence_definition_audio",
             "value": {
-                "listof": "[*]",
+                "listof": "$",
                 "value": {
                     "speaker": "speaker",
                     "filename": "filename"

--- a/mtd/tests/test_data/whitespace_manifest.json
+++ b/mtd/tests/test_data/whitespace_manifest.json
@@ -30,7 +30,7 @@
         "example_sentence_audio": {
             "listof": "example_sentence_audio",
             "value": {
-                "listof": "[*]",
+                "listof": "$",
                 "value": {
                     "speaker": "speaker",
                     "filename": "filename"
@@ -40,7 +40,7 @@
         "example_sentence_definition_audio": {
             "listof": "example_sentence_definition_audio",
             "value": {
-                "listof": " [*]",
+                "listof": " $",
                 "value": {
                     "speaker": "speaker",
                     "filename": "filename"

--- a/mtd/tests/test_dict_parser.py
+++ b/mtd/tests/test_dict_parser.py
@@ -8,7 +8,8 @@ from mtd.parsers import parse
 class DictParserTest(TestCase):
     def setUp(self):
         self.path = os.path.dirname(json_path.__file__)
-        self.data = [(SAMPLE_DATA_OBJ, SAMPLE_DATA_DF, SAMPLE_DATA_OBJ), (SAMPLE_DATA_OBJ_REDUCED_EMPTY, SAMPLE_DATA_DF_REDUCED_EMPTY, SAMPLE_DATA_OBJ_REDUCED_EMPTY)]
+        self.data = [(SAMPLE_DATA_OBJ, SAMPLE_DATA_DF, SAMPLE_DATA_OBJ),
+                     (SAMPLE_DATA_OBJ_REDUCED_EMPTY, SAMPLE_DATA_DF_REDUCED_EMPTY, SAMPLE_DATA_OBJ_REDUCED_EMPTY)]
         self.manifest = os.path.join(self.path, 'dict_manifest.json')
         self.maxDiff = None
 

--- a/mtd/tests/test_json_parser.py
+++ b/mtd/tests/test_json_parser.py
@@ -33,5 +33,111 @@ class JsonParserTest(TestCase):
             parsed_data_obj = parsed_data['data'].to_dict(orient='records')
             self.assertEqual(data[2], parsed_data_obj)
 
+    def test_listofs(self):
+        """Make sure listof semantics matches the documentation."""
+        DATA = {
+            "spam": "spam",
+            "eggs": "eggs",
+            "audio": {
+                "speaker": "Eric Idle",
+                "filename": "spam.mp3"
+            },
+            "examples": [ "spam", "spam", "eggs", "spam" ],
+            "example_audio": [
+                { "speaker": "Viking 1" },
+                { "speaker": "Viking 2" },
+                { "speaker": "Viking 3" },
+                { "speaker": "Viking 4" },
+            ],
+            "example_audio2": [
+                [
+                    { "speaker": "Viking 1", "filename": "spam1.mp3" },
+                    { "speaker": "Viking 2", "filename": "spam2.mp3" },
+                 ],
+                [
+                    { "speaker": "Viking 3", "filename": "spam3.mp3" },
+                    { "speaker": "Viking 4", "filename": "spam4.mp3" },
+                ],
+            ],
+            "examples2": [
+                {
+                    "spam": "spam",
+                    "audio": [
+                        { "speaker": "Viking 1", "filename": "spam1.mp3" },
+                        { "speaker": "Viking 2", "filename": "spam2.mp3" },
+                    ],
+                },
+                {
+                    "spam": "eggs",
+                    "audio": [
+                        { "speaker": "Viking 3", "filename": "spam3.mp3" },
+                        { "speaker": "Viking 4", "filename": "spam4.mp3" },
+                    ],
+                },
+            ],
+        }
+        MANIFEST = {
+            "name": "Glorious Spam",
+            "sorting": "spam",
+            "targets": {
+                "word": "spam",
+                "definition": "eggs",
+                "spameggs": [ "examples[0]", "examples[2]" ],
+                "spameggs2": { "spam": "examples[0]", "eggs": "examples[2]" },
+                "vikings": { "listof": "example_audio", "value": "speaker" },
+                "examples": { "listof": "examples", "value": "$" },
+                "examples2": { "listof": "examples" },
+                "vikings2": {
+                    "listof": "example_audio2",
+                    "value": {
+                        "listof": "$",
+                        "value": {"speaker": "speaker",
+                                  "filename": "filename"},
+                    }
+                },
+                "vikings3": {
+                    "listof": "examples2",
+                    "value": {
+                        "listof": "audio",
+                        "value": {"speaker": "speaker",
+                                  "filename": "filename"},
+                    }
+                },
+            }
+        }
+        EXPECTED = {
+            "word": "spam",
+            "definition": "eggs",
+            "spameggs": [ "spam", "eggs" ],
+            "spameggs2": { "spam": "spam", "eggs": "eggs" },
+            "vikings": [ "Viking 1", "Viking 2", "Viking 3", "Viking 4" ],
+            "examples": [ "spam", "spam", "eggs", "spam" ],
+            "examples2": [ "spam", "spam", "eggs", "spam" ],
+            "vikings2": [
+                [
+                    { "speaker": "Viking 1", "filename": "spam1.mp3" },
+                    { "speaker": "Viking 2", "filename": "spam2.mp3" },
+                 ],
+                [
+                    { "speaker": "Viking 3", "filename": "spam3.mp3" },
+                    { "speaker": "Viking 4", "filename": "spam4.mp3" },
+                ],
+            ],
+            "vikings3": [
+                [
+                    { "speaker": "Viking 1", "filename": "spam1.mp3" },
+                    { "speaker": "Viking 2", "filename": "spam2.mp3" },
+                 ],
+                [
+                    { "speaker": "Viking 3", "filename": "spam3.mp3" },
+                    { "speaker": "Viking 4", "filename": "spam4.mp3" },
+                ],
+            ]
+        }
+        parsed_data = parse(MANIFEST, [DATA])
+        parsed_data_obj = parsed_data['data'].to_dict(orient='records')
+        self.assertEqual(EXPECTED, parsed_data_obj[0])
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I believe I have figured out how "listof" is supposed to work for JSON.  It is confusing because jsonpath is confusing (specifically, because it returns a list wrapped in a list if you ask for a list, but a list of items if you use `[]` anywhere in your query), but in any case, there is now a big old document in the docstring explaining it, which probably should be extracted ... somewhere.

This patch also eliminates what seem like obvious absurdities in the code and fixes a bug in the handling of nested `listof`.
